### PR TITLE
Remove wrapper `div`

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -19,18 +19,16 @@
     <header class="header">
         <img src="../img/header.png">
     </header>
-    <div class="wrapper">
-        <aside class="sidebar">
-            {% include "partials/_nav.njk" %}
-        </aside>
-        <main class="content">
-            <h1>{{ title }}</h1>
-            {{ content | safe }}
-        </main>
-        <footer class="footer f-size-small t-center">
-            <p class="t-bold">public service announcement 2000</p>
-            <p>Copyright &copy; 2000 - {% year %} by {% if meta.authorName %} {{ meta.authorName }}{% endif %}. Some rights reserved. Don't jack.</p>
-        </footer>
-    </div>
-</body>
+    <aside class="sidebar">
+      {% include "partials/_nav.njk" %}
+    </aside>
+    <main class="content">
+      <h1>{{ title }}</h1>
+      {{ content | safe }}
+    </main>
+    <footer class="footer f-size-small t-center">
+      <p class="t-bold">public service announcement 2000</p>
+      <p>Copyright &copy; 2000 - {% year %} by {% if meta.authorName %} {{ meta.authorName }}{% endif %}. Some rights reserved. Don't jack.</p>
+    </footer>
+  </body>
 </html>

--- a/src/sass/_layout.scss
+++ b/src/sass/_layout.scss
@@ -1,50 +1,53 @@
 @use "variables" as *;
 
 header {
-    max-width: 1000px;
-    margin: 0 auto;
-    margin-bottom: 1rem;
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
-.wrapper {
-    max-width: 1000px;
-    margin: 0 20px;
-    display: grid;
-    grid-gap: 10px;
+body {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: grid;
 }
 
 @media screen and (min-width: 500px) {
+  body {
+    grid-template-areas:
+      "a a a a"
+      "b c c c"
+      "d d d d";
+  }
 
-    /* no grid support? */
-    .sidebar {
-      float: left;
-      width: 19.1489%;
-    }
+  .sidebar {
+    grid-area: b;
+  }
 
-    .content {
-      float: right;
-      width: 79.7872%;
-    }
+  .content {
+    grid-area: c;
+  }
 
-    .wrapper {
-      margin: 0 auto;
-      grid-template-columns: 1fr 3fr;
-    }
+  .header {
+    grid-area: a;
+  }
 
-    .header, .footer {
-      grid-column: 1 / -1;
-      /* needed for the floated layout */
-      clear: both;
-    }
+  .footer {
+    grid-area: d;
+  }
 }
 
-.wrapper > * {
-    background-color: $c-background-light;
-    border: 2px dashed $c-border;
-    border-radius: 5px;
-    padding: 20px;
-    /* needed for the floated layout*/
-    /* margin-bottom: 100px; */
+main,
+aside,
+footer {
+  background-color: $c-background-light;
+  border: 2px dashed $c-border;
+  border-radius: 5px;
+  padding: 20px;
+  margin-top: 10px;
+}
+
+main {
+  margin-left: 10px;
 }
 
 @supports (display: grid) {


### PR DESCRIPTION
Looks the same in a side-by-side comparison. I’m not sure what the intention is with the `float` business so I’ve left that out, but we can probably figure out a way to do replace it (maybe using `@supports (display: grid)` to gate the grid layout). Apologies for the odd formatting—I was in a hurry to get to the code and our default settings appear to be quite different.

If this were a real project, I’d use relative instead of absolute values so that they’re always proportional to your content, even when I zoom in on my 4K screen. For example, picking slightly arbitrary values:

  ```css
  body {
    max-width: 60em;
  }

  @media screen and (min-width: 20em) {
    /* … */
  }
  ```

I’d also use Custom Properties instead of Sass variables or repeated values so that the browser is aware of them and they can participate in the cascade if necessary, e.g.:
  ```css
  :root {
    --spacing: 1rem;
    --c-link-dark: #0f0f0f;
  }

  main {
    margin-left: var(--spacing);
  }

  a:hover {
    color: var(--c-link-dark);
  }
  ```