### PR TITLE
Fix limit filter error

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,6 +8,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("./src/js");
 
   eleventyConfig.addShortcode("year", () => `${new Date().getFullYear()}`);
+  eleventyConfig.addNunjucksFilter("limit", (arr, limit) => arr.slice(0, limit));
 
   return {
     markdownTemplateEngine: "njk",

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,7 +7,14 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("./src/img");
   eleventyConfig.addPassthroughCopy("./src/js");
 
-  eleventyConfig.addShortcode("year", () => `${new Date().getFullYear()}`);
+  // set the date once per build to avoid different results for different calls
+  let date;
+
+  eleventyConfig.on("beforeBuild", () => {
+    date = new Date();
+  });
+
+  eleventyConfig.addShortcode("year", () => `${date.getFullYear()}`);
   eleventyConfig.addNunjucksFilter("limit", (arr, limit) => arr.slice(0, limit));
 
   return {


### PR DESCRIPTION
This fixes the build error by adding [the `limit` filter from the old version](https://github.com/flamedfury/flamedfury.com/blob/b0719d5073bae323326e9aeddad3e2c2c0870f45/.eleventy.js#L13). A few general notes:

1. The font filenames break everything on Windows. Luckily, I was able to work on the code through WSL.
2. I’d suggest working on things like this as branches instead of separate repositories, because that makes it easier to compare the code and see the changes.
3. The `year` filter is a bit dicey because it gets a new date each time it runs, which could cause different output for different calls given the right circumstances. This may not worry you, since it’s such an unlikely edge case, but I’ve put in a fix anyway.